### PR TITLE
Bootstrap iPhone automation repo

### DIFF
--- a/.gptignore
+++ b/.gptignore
@@ -1,0 +1,10 @@
+# Ignore common large or unnecessary files
+node_modules/
+*.mp4
+*.mov
+*.avi
+*.jpg
+*.jpeg
+*.png
+*.gif
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 DreamspaceNYC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+Placeholder for data samples

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# iPhone Automation Resources
+
+This repository contains utilities and templates for automating tasks on an iPhone. It relies on several third‑party apps available from the App Store. Not every app is required for all features.
+
+## Required iPhone Apps
+
+- **Shortcuts** *(required)* – used for running `.shortcut.json` files.
+- **a-Shell** or **iSH** *(optional)* – command line apps for running shell scripts.
+- **Pyto** or **Pythonista** *(optional)* – run Python scripts on device.
+
+## Importing Shortcuts
+
+1. Open the Shortcuts app.
+2. Tap the "+" button and choose **Add Shortcut**.
+3. Select **Import File** and choose any file from the `/shortcuts` folder ending in `.shortcut.json`.
+4. Review the actions and tap **Add Shortcut** to finish.
+
+## Running Shell Scripts
+
+1. Open **a-Shell** or **iSH** on your iPhone.
+2. Navigate to the `/shell` folder using `cd`.
+3. Run the script with `sh scriptname.sh` or make it executable with `chmod +x` and run `./scriptname.sh`.
+
+## Using HTML Tools
+
+Single‑file utilities in `/html-tools` can be opened directly in Safari:
+
+1. Browse to the file in the Files app.
+2. Tap **Share** and choose **Open in Safari**.
+
+## Editing with Codex
+
+To update these files with Codex:
+
+1. Clone or pull this repository on your computer.
+2. Make your changes locally and commit them with a descriptive message.
+3. Push to GitHub and open a pull request.
+4. Codex will review the pull request and run automated checks before merging.

--- a/html-tools/README.md
+++ b/html-tools/README.md
@@ -1,0 +1,1 @@
+Placeholder for HTML utilities

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,1 @@
+Placeholder for python scripts

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,1 @@
+Placeholder for shell scripts

--- a/shortcuts/README.md
+++ b/shortcuts/README.md
@@ -1,0 +1,1 @@
+Placeholder for shortcut files


### PR DESCRIPTION
## Summary
- add MIT license and gptignore
- document required iPhone apps and usage in docs/README
- create empty folders for iPhone automation examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f8d881c408321bc1cefdc53e508cb